### PR TITLE
feat: support windows environments in the start script

### DIFF
--- a/exercises/npm-registry/package.json
+++ b/exercises/npm-registry/package.json
@@ -7,7 +7,7 @@
     "node": "^12.0.0"
   },
   "scripts": {
-    "start": "tsc-watch --onSuccess 'node -r source-map-support/register .'",
+    "start": "tsc-watch --onSuccess \"node -r source-map-support/register .\"",
     "test": "jest",
     "lint": "eslint --cache '{src,test}/**/*.ts'"
   },


### PR DESCRIPTION
We've had multiple instances of candidates reporting issues
when running the exercise start script on Windows. It doesn't
like the single quotes.